### PR TITLE
Fix parameter order in prepare_keypair function call

### DIFF
--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -595,7 +595,7 @@ fn main() {
             ptau_path,
             circuit_path,
             output,
-        } => prepare_keypair(&ptau_path, &output, &circuit_path, &args.arch),
+        } => prepare_keypair(&ptau_path, &circuit_path, &output, &args.arch),
         Commands::PrepareInput {
             vcek_path,
             report_path,


### PR DESCRIPTION
Swapped circuit_path and output parameters to match the function signature.

## Problem
The parameters were swapped when calling the `prepare_keypair` function, causing circuit_path and output to be used incorrectly.

## Fix
Swapped the order of parameters in the function call to match the function signature:
- Before: `prepare_keypair(&ptau_path, &output, &circuit_path, &args.arch)`
- After: `prepare_keypair(&ptau_path, &circuit_path, &output, &args.arch)`

This ensures that the function receives parameters in the correct order, preventing potential errors when using custom directory paths.